### PR TITLE
fix terminal menu deprecation

### DIFF
--- a/src/InteractiveErrors.jl
+++ b/src/InteractiveErrors.jl
@@ -191,7 +191,7 @@ function explore(io::IO, err::CapturedError; interactive = true)
         end
     end
 
-    result = interactive ? request(MultiSelectMenu(first.(actions))) : collect(1:length(actions))
+    result = interactive ? request(MultiSelectMenu(first.(actions), charset=:unicode)) : collect(1:length(actions))
     choice = sort(collect(result))
     if !isempty(choice)
         output = []


### PR DESCRIPTION
Hi, thanks for this awesome package!  This is a small fix for a deprecation warning that appears if you have deprecations turned on.  Since, mercifully, this package requires 1.6 in the first place, we don't have to worry about backward compatibility.