### PR TITLE
Fixup windows stdlib path handling

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,6 @@ using Test, InteractiveErrors
     @test isfile(InteractiveErrors.find_source(package))
     @test startswith(InteractiveErrors.rewrite_path(build), "@stdlib")
     @test startswith(InteractiveErrors.rewrite_path(stdlib), "@stdlib")
-    @test startswith(InteractiveErrors.rewrite_path(package), "~")
 
     @test isa(IE.wrap_errors(:(1 + 1)), Expr)
     @test isa(IE.wrap_errors(:(toggle())), Expr)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,16 @@ using Test, InteractiveErrors
     @test !IE.is_from_core(InteractiveErrors)
     @test IE.is_from_core(Core)
 
+    build = joinpath(normpath(Sys.BUILD_STDLIB_PATH), "Test", "src", "Test.jl")
+    stdlib = joinpath(normpath(Sys.STDLIB), "Test", "src", "Test.jl")
+    package = @__FILE__
+    @test isfile(InteractiveErrors.find_source(build))
+    @test isfile(InteractiveErrors.find_source(stdlib))
+    @test isfile(InteractiveErrors.find_source(package))
+    @test startswith(InteractiveErrors.rewrite_path(build), "@stdlib")
+    @test startswith(InteractiveErrors.rewrite_path(stdlib), "@stdlib")
+    @test startswith(InteractiveErrors.rewrite_path(package), "~")
+
     @test isa(IE.wrap_errors(:(1 + 1)), Expr)
     @test isa(IE.wrap_errors(:(toggle())), Expr)
     toggle()


### PR DESCRIPTION
`StackFrame`s seem to contain the paths from the buildbot if they are from a stdlib. Replace them with the real stdlib path and avoid using regex for it so we don't have to escape windows path separators. Fixes #6.

@jonniedie if you're able to confirm this fix that would be great, thanks.